### PR TITLE
Use __construct

### DIFF
--- a/object-cache.php
+++ b/object-cache.php
@@ -414,7 +414,7 @@ class WP_Object_Cache {
 		return $this->mc['default'];
 	}
 
-	function WP_Object_Cache() {
+	function __construct() {
 		global $memcached_servers;
 
 		if ( isset( $memcached_servers ) )


### PR DESCRIPTION
In PHP 7.0 support for PHP 4 style constructs were deprecated. Current in PHP 7.0, I get the following error message.

`
Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; WP_Object_Cache has a deprecated constructor in /app/public.built/wp-content/dropins/memcached-redux/object-cache.php on line 121
`